### PR TITLE
Feat/archive organization

### DIFF
--- a/prisma/migrations/20250525094127_add_is_archived_to_organization/migration.sql
+++ b/prisma/migrations/20250525094127_add_is_archived_to_organization/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "OrganizationChild" ADD COLUMN     "isArchived" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,6 +54,7 @@ model OrganizationChild {
   twitter             String?
   linkedin            String?
   isAdmin             Boolean             @default(false)
+  isArchived          Boolean             @default(false)
   userId              String?             @unique
   user                User?               @relation(fields: [userId], references: [id])
   events              Event[]

--- a/src/organizations/organizations.controller.ts
+++ b/src/organizations/organizations.controller.ts
@@ -84,4 +84,9 @@ export class OrganizationsController {
   ) {
     return this.organizationsService.update(id, updateOrganizationDto);
   }
+
+  @Patch(':id/archive')
+  archiveOrganizationChild(@Param('id') id: string) {
+    return this.organizationsService.archiveOrganizationChild(id);
+  }
 }

--- a/src/organizations/organizations.service.ts
+++ b/src/organizations/organizations.service.ts
@@ -1,4 +1,10 @@
-import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import {
+  HttpException,
+  HttpStatus,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import { CreateOrganizationDto } from './dto/create-organization.dto';
 import { UpdateOrganizationDto } from './dto/update-organization.dto';
 import { PrismaService } from 'src/prisma/prisma.service';
@@ -190,6 +196,27 @@ export class OrganizationsService {
       throw new HttpException(
         error.message || 'Failed to update Organization icon',
         HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  async archiveOrganizationChild(id: string) {
+    if (!(await this.prisma.organizationChild.findFirst({ where: { id } }))) {
+      throw new NotFoundException('Organization child does not exist');
+    }
+
+    try {
+      return await this.prisma.organizationChild.update({
+        where: { id },
+        data: { isArchived: true },
+      });
+    } catch (error) {
+      throw new InternalServerErrorException(
+        'Failed to archive organization child',
+        {
+          cause: error,
+          description: 'An unexpected error occurred',
+        },
       );
     }
   }


### PR DESCRIPTION
# #73 Fullstack: Archive Organization

Link: https://tree.taiga.io/project/miggyalino-adto-by-sysdev/task/73

## schema.prisma.ts
- Added `isArchived` property in `OrganizationChild` model.
```prisma
model OrganizationChild {
  //...
  isArchived Boolean @default(false)
  //...
}
```

## organizations.controller.ts
- Add `archiveOrganizationChild` method in `OrganizationsController`.
```typescript
@Patch(':id/archive')
archiveOrganizationChild(@Param('id') id: string) {
  return this.organizationsService.archiveOrganizationChild(id);
}
```

## organizations.service.ts
- Add `archiveOrganizationChild` method in `OrganizationsService`.
```typescript
async archiveOrganizationChild(id: string) {
  if (!(await this.prisma.organizationChild.findFirst({ where: { id } }))) {
    throw new NotFoundException('Organization child does not exist');
  }

  try {
    return await this.prisma.organizationChild.update({
      where: { id },
      data: { isArchived: true },
    });
  } catch (error) {
    throw new InternalServerErrorException(
      'Failed to archive organization child',
      {
        cause: error,
        description: 'An unexpected error occurred',
      },
    );
  }
}
```

## migration.sql
- Generated an SQL file that adds `isArchived` column to `OrganizationChild` table.
```sql
-- AlterTable
ALTER TABLE "OrganizationChild" ADD COLUMN "isArchived" BOOLEAN NOT NULL DEFAULT false;
```